### PR TITLE
fix: add multi-platform image support

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           context: ./packages/server/
           file: ./packages/server/Containerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

Add _multi-platform_ container image support due to error pulling image locally from container registry.

## Links

- https://docs.docker.com/build/ci/github-actions/multi-platform/